### PR TITLE
Clean up imports & dependencies for preprocess/

### DIFF
--- a/preprocess/raven_preprocess/column_info.py
+++ b/preprocess/raven_preprocess/column_info.py
@@ -2,8 +2,6 @@
 
 from collections import OrderedDict
 import json
-import time,datetime
-import pandas as pd
 from raven_preprocess.np_json_encoder import NumpyJSONEncoder
 import raven_preprocess.col_info_constants as col_const
 

--- a/preprocess/raven_preprocess/custom_statistics_util.py
+++ b/preprocess/raven_preprocess/custom_statistics_util.py
@@ -1,9 +1,6 @@
 """ File to get the updated metadata file with custom statistics"""
 from collections import OrderedDict
-from decimal import Decimal
-import pandas as pd
 import re
-from pandas.api.types import is_float_dtype, is_numeric_dtype
 import json
 import raven_preprocess.col_info_constants as col_const
 from raven_preprocess.column_info import ColumnInfo

--- a/preprocess/raven_preprocess/custom_statistics_util.py
+++ b/preprocess/raven_preprocess/custom_statistics_util.py
@@ -2,7 +2,6 @@
 from collections import OrderedDict
 from decimal import Decimal
 import pandas as pd
-from django.utils.text import slugify
 import re
 from pandas.api.types import is_float_dtype, is_numeric_dtype
 import json

--- a/preprocess/raven_preprocess/data_source_info.py
+++ b/preprocess/raven_preprocess/data_source_info.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-import json
 from collections import OrderedDict
 
 import raven_preprocess.col_info_constants as col_const

--- a/preprocess/raven_preprocess/dataset_level_info_util.py
+++ b/preprocess/raven_preprocess/dataset_level_info_util.py
@@ -1,11 +1,7 @@
 from __future__ import print_function
 """ this is the information of dataset level info"""
 from collections import OrderedDict
-import numpy as np
-import pandas as pd
-import re
 
-from raven_preprocess.np_json_encoder import NumpyJSONEncoder
 import raven_preprocess.col_info_constants as col_const
 
 

--- a/preprocess/raven_preprocess/file_format_util.py
+++ b/preprocess/raven_preprocess/file_format_util.py
@@ -1,10 +1,7 @@
-from collections import OrderedDict
-import decimal
-import json, time, datetime
 import os
 
 import pandas as pd
-from os.path import basename, isdir, isfile, splitext
+from os.path import basename, isfile, splitext
 
 from raven_preprocess.data_source_info import DataSourceInfo, SOURCE_TYPE_FILE
 from raven_preprocess.msg_util import msg, msgt

--- a/preprocess/raven_preprocess/np_json_encoder.py
+++ b/preprocess/raven_preprocess/np_json_encoder.py
@@ -1,5 +1,4 @@
 from datetime import date, datetime
-import decimal
 import simplejson as json
 import numpy as np
 

--- a/preprocess/raven_preprocess/plot_values.py
+++ b/preprocess/raven_preprocess/plot_values.py
@@ -5,9 +5,8 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 
-from raven_preprocess.column_info import *
+from raven_preprocess.column_info import ColumnInfo
 import raven_preprocess.col_info_constants as col_const
-from raven_preprocess.type_guess_util import *
 logger = logging.getLogger(__name__)
 
 

--- a/preprocess/raven_preprocess/preprocess.py
+++ b/preprocess/raven_preprocess/preprocess.py
@@ -8,7 +8,7 @@ sys.path.append(dirname(CURRENT_DIR))
 
 from raven_preprocess.preprocess_runner import PreprocessRunner
 from raven_preprocess.basic_utils.basic_response import (ok_resp, err_resp)
-from raven_preprocess.msg_util import msg, msgt, dashes
+from raven_preprocess.msg_util import msgt
 
 logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
 

--- a/preprocess/raven_preprocess/preprocess_runner.py
+++ b/preprocess/raven_preprocess/preprocess_runner.py
@@ -4,12 +4,11 @@ from collections import OrderedDict
 import decimal
 import pandas as pd
 import os
-from os.path import isdir, isfile
+from os.path import isfile
 from raven_preprocess.basic_utils.basic_response import (ok_resp, err_resp)
 
 
 import raven_preprocess.col_info_constants as col_const
-from raven_preprocess.msg_util import msg, msgt, dashes
 from raven_preprocess.np_json_encoder import NumpyJSONEncoder
 from raven_preprocess.type_guess_util import TypeGuessUtil
 from raven_preprocess.summary_stats_util import SummaryStatsUtil

--- a/preprocess/raven_preprocess/scratch_work.py
+++ b/preprocess/raven_preprocess/scratch_work.py
@@ -1,9 +1,6 @@
 from os.path import abspath, dirname, join, normpath, isdir, isfile
-from io import StringIO
-import json
 import sys
 import pandas as pd
-import numpy as np
 
 
 PREPROCESS_DIR = dirname(dirname(abspath(__file__)))

--- a/preprocess/raven_preprocess/tests/sample_tests.py
+++ b/preprocess/raven_preprocess/tests/sample_tests.py
@@ -2,10 +2,7 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy import stats
-from scipy.stats import norm
-from sklearn.neighbors import KernelDensity
 from scipy.stats import gaussian_kde
-from statsmodels.nonparametric.kde import KDEUnivariate
 
 #
 # cnt_min = None

--- a/preprocess/raven_preprocess/tests/test_preprocess.py
+++ b/preprocess/raven_preprocess/tests/test_preprocess.py
@@ -1,17 +1,13 @@
 """Unit testing for preprocess_runner using sample data"""
 import unittest
 from unittest import skip
-from os.path import abspath, dirname, isfile, join
 import json
 import decimal
 from collections import OrderedDict
-import sys
-from os.path import \
-    (abspath, basename, dirname, isdir, isfile, join, splitext)
+from os.path import abspath, dirname, isfile, join
 
 
 import raven_preprocess.col_info_constants as col_const
-import raven_preprocess.update_constants as update_const
 from raven_preprocess.preprocess_runner import PreprocessRunner
 from raven_preprocess.data_source_info import SOURCE_TYPE_FILE
 from raven_preprocess.file_format_constants import \

--- a/preprocess/raven_preprocess/tests/test_update_preprocess.py
+++ b/preprocess/raven_preprocess/tests/test_update_preprocess.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 
 import raven_preprocess.col_info_constants as col_const
 import raven_preprocess.update_constants as update_const
-from raven_preprocess.msg_util import dashes, msgt, msg
+from raven_preprocess.msg_util import msgt
 from raven_preprocess.variable_display_util import VariableDisplayUtil
 
 TEST_DATA_DIR = join(dirname(abspath(__file__)), 'test_data')

--- a/preprocess/raven_preprocess/type_guess_util.py
+++ b/preprocess/raven_preprocess/type_guess_util.py
@@ -3,7 +3,6 @@ import pandas as pd
 from pandas.api.types import is_float_dtype, is_numeric_dtype
 
 import raven_preprocess.col_info_constants as col_const
-from raven_preprocess.column_info import ColumnInfo
 from raven_preprocess.basic_utils.basic_err_check import BasicErrCheck
 
 

--- a/preprocess/raven_preprocess/variable_display_util.py
+++ b/preprocess/raven_preprocess/variable_display_util.py
@@ -1,8 +1,5 @@
 """Module for a variable's display settings"""
 from collections import OrderedDict
-from decimal import Decimal
-import pandas as pd
-from pandas.api.types import is_float_dtype, is_numeric_dtype
 import json
 
 import raven_preprocess.col_info_constants as col_const

--- a/preprocess/setup.py
+++ b/preprocess/setup.py
@@ -48,6 +48,5 @@ setuptools.setup(
             'simplejson>=3.13.2',
             'xlrd>=1.1.0',
             'jsonschema>=2.6.0',
-            'fabric>=2.5.0'
         ],
 )


### PR DESCRIPTION
Fixes #194

* Remove Django import from `custom_statistics_util.py`
* Remove fabric from dependencies in `setup.py` (not used by the library)
* Fix imports (remove unused imports, fix importing through `*`)